### PR TITLE
Integrate Attesation Managers

### DIFF
--- a/apps/case-gs-step2/vm/CMakeLists.txt
+++ b/apps/case-gs-step2/vm/CMakeLists.txt
@@ -85,6 +85,30 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
 endfunction(MyAddExternalProjFilesToOverlay)
 
 ExternalProject_Add(
+    useram
+    GIT_REPOSITORY
+    https://github.com/gaj7/am-bin-gs.git
+    GIT_TAG
+    master
+    INSTALL_COMMAND
+    ""
+    UPDATE_COMMAND
+    ""
+    CONFIGURE_COMMAND
+    ""
+    BUILD_COMMAND
+    ""
+)
+MyAddExternalProjFilesToOverlay(
+    useram
+    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    overlay_radio
+    "usr/bin"
+    FILES
+    groundstation
+)
+
+ExternalProject_Add(
     UxASGS
     GIT_REPOSITORY
     https://github.com/loonwerks/case-ta6-experimental-platform-OpenUxAS.git
@@ -191,4 +215,3 @@ CAmkESAddImportPath(${CMAKE_CURRENT_SOURCE_DIR}/${KernelARMPlatform}/)
 # DeclareCAmkESComponent(VM LIBS queue)
 
 CAmkESAddCPPInclude(${CAMKES_ARM_VM_DIR}/components/VM)
-

--- a/apps/case-gs-step2/vm/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-gs-step2/vm/overlay_files/init_scripts/inittab_hvc0
@@ -34,6 +34,9 @@ null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
 # Put a getty on the serial port
 hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 
+# Run AM
+::respawn:groundstation
+
 # Stuff to do for the 3-finger salute
 #::ctrlaltdel:/sbin/reboot
 

--- a/apps/case-uav-step5/CMakeLists.txt
+++ b/apps/case-uav-step5/CMakeLists.txt
@@ -19,6 +19,7 @@ camkes_arm_vm_import_project()
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/hexdump)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/camkes_log_queue)
+add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/am_queue)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/queue)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/components/AttestationGate)
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR}/components/AutopilotSerialServer)
@@ -34,4 +35,3 @@ DeclareCAmkESRootserver(case-uav-step5.camkes)
 AddToFileServer("linux" "${CAMKES_VM_IMAGES_DIR}/${KernelARMPlatform}/linux")
 
 DefineCAmkESVMFileServer()
-

--- a/apps/case-uav-step5/am_queue/CMakeLists.txt
+++ b/apps/case-uav-step5/am_queue/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+cmake_minimum_required(VERSION 3.7.2)
+
+project(am_queue C)
+
+add_library(am_queue EXCLUDE_FROM_ALL src/am_queue.c)
+
+# Assume that if the muslc target exists then this project is in an seL4 native
+# component build environment, otherwise it is in a linux userlevel environment.
+# In the linux userlevel environment, the C library will be linked automatically.
+if(TARGET muslc)
+	target_link_libraries(am_queue muslc)
+endif()
+
+target_include_directories(am_queue PUBLIC include)

--- a/apps/case-uav-step5/am_queue/include/am_counter.h
+++ b/apps/case-uav-step5/am_queue/include/am_counter.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+// Defs to allow easy changing of counter type. Keep these consistent!
+typedef uintmax_t counter_t;
+#define COUNTER_MAX UINTMAX_MAX
+#define PRIcounter PRIuMAX

--- a/apps/case-uav-step5/am_queue/include/am_data.h
+++ b/apps/case-uav-step5/am_queue/include/am_data.h
@@ -1,0 +1,18 @@
+#pragma once
+
+// The event data port type. Sender and receiver type must match. Many ports can use the same type.
+// The data representation is independent of the queue representation.
+//
+// NOTE: data_t must define a type for which assignment will copy all the
+// data. For example, pointers do not work.
+
+#include <stdint.h>
+#include <sys/types.h>
+
+// #define DATA_T_MAX_PAYLOAD (8192 - sizeof(unsigned long long int))
+// #define DATA_T_MAX_PAYLOAD (19 - sizeof(unsigned long long int))
+#define DATA_T_MAX_PAYLOAD 12
+
+typedef struct data {
+  uint8_t payload[DATA_T_MAX_PAYLOAD];
+} data_t;

--- a/apps/case-uav-step5/am_queue/include/am_queue.h
+++ b/apps/case-uav-step5/am_queue/include/am_queue.h
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+// Single sender multiple receiver Queue implementation for AADL Event Data
+// Ports. Every receiver receives the sent data (ie brodcast). The queue
+// operations are all non-blocking. The sender enqueue always succeeds. A
+// receiver dequeue can fail and drop data if the sender writes while the
+// receiver is reading. This situation is detected unless the sender gets
+// ahead of a receiver by more than COUNTER_MAX. Since COUNTER_MAX is typically
+// 2^64 (see counter.h), this is extremely unlikely. If it does happen the
+// only adverse effect is that the receiver will not detect all dropped
+// elements.
+
+#pragma once
+
+#ifdef __cplusplus
+#extern "C" {
+#endif
+
+#include <am_counter.h>
+#include <am_data.h>
+#include <stdbool.h>
+
+// Queue size must be an integer factor of the size for counter_t (an unsigned
+// integer type). Since we are using standard C unsigned integers for the
+// counter, picking a queue size that is a power of 2 is a good choice. We
+// could alternatively set the size of our counter to the largest possible
+// multiple of queue size. But then we would need to do our own modulo
+// operations on the counter rather than depending on c's unsigned integer
+// operations.
+//
+// Note: One cell in the queue is always considered dirty. Its the next
+// element to be written. Thus the queue can only contain QUEUE_SIZE-1
+// elements.
+#define QUEUE_SIZE 4
+
+// This is the type of the seL4 dataport (shared memory) that is shared by the
+// sender and all receivers. This type is referenced in the sender and receiver
+// CAmkES component definition files. The seL4 CAmkES runtime creates an
+// instance of this struct.
+typedef struct queue {
+  // Number of elements enqueued since the sender. The implementation depends
+  // on C's standard module behaviour for unsigned integers. The counter never
+  // overflows. It just wraps modulo the size of the counter type. The counter
+  // is typically very large (see counter.h), so this should happen very
+  // infrequently. Depending in C to initialize this to zero.
+  _Atomic counter_t numSent;
+  // Queue of elements of type data_t (see data.h) implemented as a ring buffer.
+  // No initialization necessary.
+  data_t elt[QUEUE_SIZE];
+} queue_t;
+
+//------------------------------------------------------------------------------
+// Sender API
+//
+// Could split this into separate header and source file since only sender
+// code needs this.
+
+// Initialize the queue. Sender must call this exactly once before any calls to queue_enqueue();
+void queue_init(queue_t *queue);
+
+// Enqueue data. This always succeeds and never blocks. Data is copied.
+void queue_enqueue(queue_t *queue, data_t *data);
+
+//------------------------------------------------------------------------------
+// Receiver API
+//
+// Could split this into separate header and source file since only receiver
+// code needs this.
+
+// Each receiver needs to create an instance of this.
+typedef struct recv_queue {
+  // Number of elements dequeued (or dropped) by a receiver. The implementation
+  // depends on C's standard module behaviour for unsigned integers. The
+  // counter never overflows. It just wraps modulo the size of the counter
+  // type. The counter is typically very large (see counter.h), so this should
+  // happen very infrequently.
+  counter_t numRecv;
+  // Pointer to the actual queue. This is the seL4 dataport (shared memory)
+  // that is shared by the sender and all receivers.
+  queue_t *queue;
+} recv_queue_t;
+
+// Each receiver must call this exactly once before any calls to other queue
+// API functions.
+void recv_queue_init(recv_queue_t *recvQueue, queue_t *queue);
+
+// Dequeue data. Never blocks but can fail if the sender writes at same
+// time.
+
+// When successful returns true. The dequeued data will be copied to
+// *data. *numDropped will contain the number of elements that were dropped
+// since the last call to queue_dequeue().
+//
+// When queue is empty, returns false and *numDropped is zero. *data is left in
+// unspecified state.
+//
+// When dequeue fails due to possible write of data being read, returns false
+// and *numDropped will be >= 1 specifying the number of elements that were
+// dropped since the last call to queue_dequeue(). *data is left in
+// unspecified state.
+//
+// If the sender ever gets ahead of a receiver by more than COUNTER_MAX,
+// recv_dequeue will fail to count a multiple of COUNTER_MAX in
+// numDropped. Since COUNTER_MAX is very large (typically on the order of 2^64,
+// see counter.h), this is very unlikely.  If the sender is ever this far
+// ahead of a receiver the system is probably in a very bad state.
+bool queue_dequeue(recv_queue_t *recvQueue, counter_t *numDropped, data_t *data);
+
+// Is queue empty? If the queue is not empty, it will stay that way until the
+// receiver dequeues all data. If the queue is empty you can make no
+// assumptions about how long it will stay empty.
+bool queue_is_empty(recv_queue_t *recvQueue);
+
+#ifdef __cplusplus
+}
+#endif

--- a/apps/case-uav-step5/am_queue/src/am_queue.c
+++ b/apps/case-uav-step5/am_queue/src/am_queue.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017, Data61
+ * Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+ * ABN 41 687 119 230.
+ *
+ * Copyright 2019 Adventium Labs
+ * Modifications made to original
+ *
+ * This software may be distributed and modified according to the terms of
+ * the BSD 2-Clause license. Note that NO WARRANTY is provided.
+ * See "LICENSE_BSD2.txt" for details.
+ *
+ * @TAG(DATA61_Adventium_BSD)
+ */
+
+#ifdef __cplusplus
+#extern "C" {
+#endif
+
+#include <am_queue.h>
+#include <stdint.h>
+#include <stddef.h>
+
+//------------------------------------------------------------------------------
+// Sender API
+//
+// See queue.h for API documentation. Only implementation details are documented here.
+
+void queue_init(queue_t *queue) {
+  // NOOP for now. C's struct initialization is sufficient.  If we ever do need
+  // initialization logic, we may also need to synchronize with receiver
+  // startup.
+}
+
+void queue_enqueue(queue_t *queue, data_t *data) {
+  // Simple ring with one dirty element that will be written next. Only one
+  // writer, so no need for any synchronization. elt[queue->numSent %
+  // QUEUE_SIZE] is always considered dirty. So do not advance queue-NumSent
+  // till AFTER data is copied.
+
+  size_t i = queue->numSent % QUEUE_SIZE;
+  queue->elt[i] = *data; // Copy data into queue
+  // Release memory fence - ensure that data write above completes BEFORE we advance queue->numSent
+  __atomic_thread_fence(__ATOMIC_RELEASE);
+  ++(queue->numSent);
+}
+
+//------------------------------------------------------------------------------
+// Receiver API
+//
+// See queue.h for API documentation. Only implementation details are documented here.
+
+void recv_queue_init(recv_queue_t *recvQueue, queue_t *queue) {
+  recvQueue->numRecv = 0;
+  recvQueue->queue = queue;
+}
+
+bool queue_dequeue(recv_queue_t *recvQueue, counter_t *numDropped, data_t *data) {
+  counter_t *numRecv = &recvQueue->numRecv;
+  queue_t *queue = recvQueue->queue;
+  // Get a copy of numSent so we can see if it changes durring read
+  counter_t numSent = queue->numSent;
+  // Acquire memory fence - ensure read of queue->numSent BEFORE reading data
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+  // How many new elements have been sent? Since we are using unsigned
+  // integers, this correctly computes the value as counters wrap.
+  counter_t numNew = numSent - *numRecv;
+  if (0 == numNew) {
+    // Queue is empty
+    return false;
+  }
+  // One element in the ring buffer is always considered dirty. Its the next
+  // element we will write.  It's not safe to read it until numSent has been
+  // incremented. Thus there are really only (QUEUE_SIZE - 1) elements in the
+  // queue.
+  *numDropped = (numNew <= QUEUE_SIZE - 1) ? 0 : numNew - QUEUE_SIZE + 1;
+  // Increment numRecv by *numDropped plus one for the element we are about to
+  // read.
+  *numRecv += *numDropped + 1;
+  counter_t numRemaining = numSent - *numRecv;
+  size_t i = (*numRecv - 1) % QUEUE_SIZE;
+  *data = queue->elt[i]; // Copy data
+  // Acquire memory fence - ensure read of data BEFORE reading queue->numSent again
+  __atomic_thread_fence(__ATOMIC_ACQUIRE);
+  if (queue->numSent - *numRecv + 1 < QUEUE_SIZE) {
+    // Sender did not write element we were reading. Copied data is coherent.
+    return true;
+  } else {
+    // Sender may have written element we were reading. Copied data may be incoherent.
+    // We dropped the element we were trying to read, so increment *numDropped.
+    ++(*numDropped);
+    return false;
+  }
+}
+
+bool queue_is_empty(recv_queue_t *recvQueue) {
+  return (recvQueue->queue->numSent == recvQueue->numRecv);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/apps/case-uav-step5/components/AttestationGate/AttestationGate.camkes
+++ b/apps/case-uav-step5/components/AttestationGate/AttestationGate.camkes
@@ -12,7 +12,7 @@
  */
 
 component AttestationGate {
-    include <queue.h>;
+    include <am_queue.h>;
     control;
 
     // trusted_ids_in - AADL Event Data Port (in) representation
@@ -52,4 +52,3 @@ component AttestationGate {
 
 
 }
-

--- a/apps/case-uav-step5/components/AttestationGate/CMakeLists.txt
+++ b/apps/case-uav-step5/components/AttestationGate/CMakeLists.txt
@@ -20,5 +20,5 @@ DeclareCAmkESComponent(AttestationGate
     src/attestation_gate.c
     LIBS
     hexdump
-    queue
+    am_queue
 )

--- a/apps/case-uav-step5/components/AttestationGate/src/attestation_gate.c
+++ b/apps/case-uav-step5/components/AttestationGate/src/attestation_gate.c
@@ -7,9 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <counter.h>
-#include <data.h>
-#include <queue.h>
+#include <am_counter.h>
+#include <am_data.h>
+#include <am_queue.h>
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -27,8 +27,15 @@
 // User specified input data receive handler for AADL Input Event Data Port (in) named
 // "p1_in".
 void trusted_ids_in_event_data_receive(counter_t numDropped, data_t *data) {
-    printf("%s: received trusted ids: numDropped: %" PRIcounter "\n", get_instance_name(), numDropped);
-    hexdump("    ", 32, data->payload, sizeof(data->payload));
+    printf("%s received trusted id list:", get_instance_name());
+    for(int i = 0; i < 3; i++) {
+        printf(" ");
+        for(int j = 0; j < 4; j++)
+            printf("%02X", data->payload[4*i+j]);
+    }
+    printf("; numDropped: %" PRIcounter "\n", numDropped);
+    // printf("%s: received trusted ids: numDropped: %" PRIcounter "\n", get_instance_name(), numDropped);
+    // hexdump("    ", 32, data->payload, sizeof(data->payload));
 }
 
 recv_queue_t trustedIdsInRecvQueue;
@@ -47,9 +54,9 @@ bool trusted_ids_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     // hexdump("    ", 32, data->payload, sizeof(data->payload));
 //     operating_region_out_event_data_send(data);
 // }
-// 
+//
 // recv_queue_t operatingRegionInRecvQueue;
-// 
+//
 // Assumption: only one thread is calling this and/or reading p1_in_recv_counter.
 // bool operating_region_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     return queue_dequeue(&operatingRegionInRecvQueue, numDropped, data);
@@ -64,10 +71,10 @@ bool trusted_ids_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     // hexdump("    ", 32, data->payload, sizeof(data->payload));
 //     line_search_task_out_event_data_send(data);
 // }
-// 
-// 
+//
+//
 // recv_queue_t lineSearchTaskInRecvQueue;
-// 
+//
 // Assumption: only one thread is calling this and/or reading p1_in_recv_counter.
 // bool line_search_task_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     return queue_dequeue(&lineSearchTaskInRecvQueue, numDropped, data);
@@ -82,10 +89,10 @@ bool trusted_ids_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     // hexdump("    ", 32, data->payload, sizeof(data->payload));
 //     automation_request_out_event_data_send(data);
 // }
-// 
-// 
+//
+//
 // recv_queue_t automationRequestInRecvQueue;
-// 
+//
 // Assumption: only one thread is calling this and/or reading p1_in_recv_counter.
 // bool automation_request_in_event_data_poll(counter_t *numDropped, data_t *data) {
 //     return queue_dequeue(&automationRequestInRecvQueue, numDropped, data);
@@ -169,4 +176,3 @@ int run(void) {
 
     run_poll();
 }
-

--- a/apps/case-uav-step5/vmRadio/CMakeLists.txt
+++ b/apps/case-uav-step5/vmRadio/CMakeLists.txt
@@ -160,6 +160,30 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
 endfunction(MyAddExternalProjFilesToOverlay)
 
 ExternalProject_Add(
+    useram
+    GIT_REPOSITORY
+    https://github.com/gaj7/am-bin-uav.git
+    GIT_TAG
+    master
+    INSTALL_COMMAND
+    ""
+    UPDATE_COMMAND
+    ""
+    CONFIGURE_COMMAND
+    ""
+    BUILD_COMMAND
+    ""
+)
+MyAddExternalProjFilesToOverlay(
+    useram
+    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    overlay_radio
+    "usr/bin"
+    FILES
+    uav
+)
+
+ExternalProject_Add(
     camkes_log_relay
     SOURCE_DIR
     ${CMAKE_CURRENT_SOURCE_DIR}/apps/camkes_log_relay
@@ -194,7 +218,7 @@ ExternalProject_Add(
     INSTALL_COMMAND
     ""
     UPDATE_COMMAND
-    "" 
+    ""
     CONFIGURE_COMMAND
     cd <SOURCE_DIR> && ./prepare && cd <BINARY_DIR> && meson setup <BINARY_DIR> <SOURCE_DIR> --cross-file=<SOURCE_DIR>/camkes-vm-arm-linux-gnueabi-cross-file.txt --buildtype=release
     BUILD_COMMAND
@@ -275,4 +299,3 @@ DeclareCAmkESComponent(Radio_VM LIBS queue)
 CAmkESAddCPPInclude(${CAMKES_ARM_VM_DIR}/components/VM)
 
 DeclareCAmkESARMVM(Radio_VM)
-

--- a/apps/case-uav-step5/vmRadio/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-uav-step5/vmRadio/overlay_files/init_scripts/inittab_hvc0
@@ -54,6 +54,9 @@ hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 ::wait:chmod g+rw /dev/uio3
 ::wait:chmod g+rw /dev/uio4
 
+# Run AM
+::respawn:uav
+
 # Run UxAS
 # ::respawn:su uxas -c "/usr/bin/camkes_log_relay /dev/uio3 192.168.2.2:5578"
 ::respawn:su uxas -c "mkdir -p /home/uxas/ex/p2/01_Waterway/RUNDIR && cd /home/uxas/ex/p2/01_Waterway/RUNDIR && /home/uxas/build/uxas -cfgPath /home/uxas/ex/p2/01_Waterway/cfg_WaterwaySearch_UAV.xml"


### PR DESCRIPTION
This merge would add attestation managers (AMs) to the `case-gs-step1` and `case-uav-step1` apps, as well as a placeholder AM Gate in the `uav` to demonstrate writing the `id_list`. Please let me know if the AMs should be added to different apps (in particular, I'm not sure if the uav changes should have been made to `case-uav-step3` instead of `step1`), and I can make that change easily enough.

Some notes on the changes:
The AM repo is currently private due to some sensitive code. We can invite those who need access, but we can't make it public at the moment. The CMake `ExternalProject` commands do not appear to work with private repos, so you will need to manually clone the repo into both apps, e.g. `git clone https://github.com/ku-sldg/cakeml-am -b demo` in `case-gs-step1/vm/` and `case-uav-step1/vm`.

Second, you will need to add the following to the following to the sel4 `extras.dockerfile`:
```
curl https://cakeml.org/cake-x64-32.tar.gz > cake-x64-32.tar.gz \
&& tar -xvzf cake-x64-32.tar.gz && cd cake-x64-32 && make cake \
&& mv cake /usr/bin/cake32
```
This will provide the docker image with the CakeML compiler and basis library FFI needed to build the AM.

The rest of the build process should be unaffected.

Finally, I just want to make sure that the statically assigned IP addresses I find in the overlay files will be the same that will be used in the demo. Currently, these values are hardcoded in to the AM, so the AM will need to be updated if the IP addresses change.