### PR TITLE
Incorporate new AMs

### DIFF
--- a/apps/case-gs-step2/vm/CMakeLists.txt
+++ b/apps/case-gs-step2/vm/CMakeLists.txt
@@ -124,28 +124,41 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
     endforeach()
 endfunction(MyAddExternalProjFilesToOverlay)
 
+find_program(CAKE NAMES cake32 cake PATHS "~/cake-x64-x32/" "/cake-x64-x32/" DOC "32-bit targeting CakeML compiler")
+if("${CAKE}" STREQUAL "CAKE-NOTFOUND")
+    message(FATAL_ERROR "Could not find a 32-bit targeting CakeML compiler. Please ensure cake32 is on the system path.")
+endif()
+find_program(armhf-gcc NAMES arm-linux-gnueabihf-gcc)
+if("${armhf-gcc}" STREQUAL "armhf-gcc-NOTFOUND")
+    message(FATAL_ERROR "Could not find arm-linux-gnueabihf-gcc, please install and place on the system path.")
+endif()
 ExternalProject_Add(
     useram
     GIT_REPOSITORY
-    https://github.com/gaj7/am-bin-gs.git
+    https://github.com/ku-sldg/am-cakeml.git
     GIT_TAG
-    meas
+    dev-case
     INSTALL_COMMAND
     ""
-    UPDATE_COMMAND
-    ""
-    CONFIGURE_COMMAND
-    ""
     BUILD_COMMAND
-    ""
+    cmake --build . --target gs_am
+    BUILD_ALWAYS
+    ON 
+    CMAKE_ARGS 
+        -DCMAKE_C_COMPILER=${armhf-gcc}
+        -DCMAKE_C_FLAGS=${BASE_C_FLAGS}
+        -DCAKE=${CAKE}
+        -DSTATIC_LINKING=ON
 )
+ExternalProject_Get_property(useram DOWNLOAD_DIR)
+message(STATUS "\nuseram download dir: ${DOWNLOAD_DIR}\n")
 MyAddExternalProjFilesToOverlay(
     useram
-    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    ${DOWNLOAD_DIR}/useram-build
     overlay
     "usr/bin"
     FILES
-    groundstation
+    gs_am
 )
 
 ExternalProject_Add(

--- a/apps/case-gs-step2/vm/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-gs-step2/vm/overlay_files/init_scripts/inittab_hvc0
@@ -35,7 +35,7 @@ null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
 hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 
 # Run AM
-::respawn:groundstation
+::respawn:gs_am 192.168.2.7
 
 # Stuff to do for the 3-finger salute
 #::ctrlaltdel:/sbin/reboot

--- a/apps/case-gs-threat-3A1/vm/CMakeLists.txt
+++ b/apps/case-gs-threat-3A1/vm/CMakeLists.txt
@@ -124,28 +124,41 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
     endforeach()
 endfunction(MyAddExternalProjFilesToOverlay)
 
+find_program(CAKE NAMES cake32 cake PATHS "~/cake-x64-x32/" "/cake-x64-x32/" DOC "32-bit targeting CakeML compiler")
+if("${CAKE}" STREQUAL "CAKE-NOTFOUND")
+    message(FATAL_ERROR "Could not find a 32-bit targeting CakeML compiler. Please ensure cake32 is on the system path.")
+endif()
+find_program(armhf-gcc NAMES arm-linux-gnueabihf-gcc)
+if("${armhf-gcc}" STREQUAL "armhf-gcc-NOTFOUND")
+    message(FATAL_ERROR "Could not find arm-linux-gnueabihf-gcc, please install and place on the system path.")
+endif()
 ExternalProject_Add(
     useram
     GIT_REPOSITORY
-    https://github.com/gaj7/am-bin-gs.git
+    https://github.com/ku-sldg/am-cakeml.git
     GIT_TAG
-    meas
+    dev-case
     INSTALL_COMMAND
     ""
-    UPDATE_COMMAND
-    ""
-    CONFIGURE_COMMAND
-    ""
     BUILD_COMMAND
-    ""
+    cmake --build . --target gs_am
+    BUILD_ALWAYS
+    ON 
+    CMAKE_ARGS 
+        -DCMAKE_C_COMPILER=${armhf-gcc}
+        -DCMAKE_C_FLAGS=${BASE_C_FLAGS}
+        -DCAKE=${CAKE}
+        -DSTATIC_LINKING=ON
 )
+ExternalProject_Get_property(useram DOWNLOAD_DIR)
+message(STATUS "\nuseram download dir: ${DOWNLOAD_DIR}\n")
 MyAddExternalProjFilesToOverlay(
     useram
-    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    ${DOWNLOAD_DIR}/useram-build
     overlay
     "usr/bin"
     FILES
-    groundstation
+    gs_am
 )
 
 ExternalProject_Add(

--- a/apps/case-gs-threat-3A1/vm/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-gs-threat-3A1/vm/overlay_files/init_scripts/inittab_hvc0
@@ -35,7 +35,7 @@ null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
 hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 
 # Run AM
-::respawn:groundstation
+::respawn:gs_am 192.168.2.7
 
 # Stuff to do for the 3-finger salute
 #::ctrlaltdel:/sbin/reboot

--- a/apps/case-gs-threat-3A2/vm/CMakeLists.txt
+++ b/apps/case-gs-threat-3A2/vm/CMakeLists.txt
@@ -124,28 +124,41 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
     endforeach()
 endfunction(MyAddExternalProjFilesToOverlay)
 
+find_program(CAKE NAMES cake32 cake PATHS "~/cake-x64-x32/" "/cake-x64-x32/" DOC "32-bit targeting CakeML compiler")
+if("${CAKE}" STREQUAL "CAKE-NOTFOUND")
+    message(FATAL_ERROR "Could not find a 32-bit targeting CakeML compiler. Please ensure cake32 is on the system path.")
+endif()
+find_program(armhf-gcc NAMES arm-linux-gnueabihf-gcc)
+if("${armhf-gcc}" STREQUAL "armhf-gcc-NOTFOUND")
+    message(FATAL_ERROR "Could not find arm-linux-gnueabihf-gcc, please install and place on the system path.")
+endif()
 ExternalProject_Add(
     useram
     GIT_REPOSITORY
-    https://github.com/gaj7/am-bin-gs.git
+    https://github.com/ku-sldg/am-cakeml.git
     GIT_TAG
-    meas
+    dev-case
     INSTALL_COMMAND
     ""
-    UPDATE_COMMAND
-    ""
-    CONFIGURE_COMMAND
-    ""
     BUILD_COMMAND
-    ""
+    cmake --build . --target gs_am
+    BUILD_ALWAYS
+    ON 
+    CMAKE_ARGS 
+        -DCMAKE_C_COMPILER=${armhf-gcc}
+        -DCMAKE_C_FLAGS=${BASE_C_FLAGS}
+        -DCAKE=${CAKE}
+        -DSTATIC_LINKING=ON
 )
+ExternalProject_Get_property(useram DOWNLOAD_DIR)
+message(STATUS "\nuseram download dir: ${DOWNLOAD_DIR}\n")
 MyAddExternalProjFilesToOverlay(
     useram
-    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    ${DOWNLOAD_DIR}/useram-build
     overlay
     "usr/bin"
     FILES
-    groundstation
+    gs_am
 )
 
 ExternalProject_Add(

--- a/apps/case-gs-threat-3A2/vm/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-gs-threat-3A2/vm/overlay_files/init_scripts/inittab_hvc0
@@ -35,7 +35,7 @@ null::sysinit:/bin/ln -sf /proc/self/fd/2 /dev/stderr
 hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 
 # Run AM
-::respawn:groundstation
+::respawn:gs_am 192.168.2.7
 
 # Stuff to do for the 3-finger salute
 #::ctrlaltdel:/sbin/reboot

--- a/apps/case-uav-step5/vmRadio/CMakeLists.txt
+++ b/apps/case-uav-step5/vmRadio/CMakeLists.txt
@@ -159,28 +159,41 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
     endforeach()
 endfunction(MyAddExternalProjFilesToOverlay)
 
+find_program(CAKE NAMES cake32 cake PATHS "~/cake-x64-x32/" "/cake-x64-x32/" DOC "32-bit targeting CakeML compiler")
+if("${CAKE}" STREQUAL "CAKE-NOTFOUND")
+    message(FATAL_ERROR "Could not find a 32-bit targeting CakeML compiler. Please ensure cake32 is on the system path.")
+endif()
+find_program(armhf-gcc NAMES arm-linux-gnueabihf-gcc)
+if("${armhf-gcc}" STREQUAL "armhf-gcc-NOTFOUND")
+    message(FATAL_ERROR "Could not find arm-linux-gnueabihf-gcc, please install and place on the system path.")
+endif()
 ExternalProject_Add(
     useram
     GIT_REPOSITORY
-    https://github.com/gaj7/am-bin-uav.git
+    https://github.com/ku-sldg/am-cakeml.git
     GIT_TAG
-    meas
+    dev-case
     INSTALL_COMMAND
     ""
-    UPDATE_COMMAND
-    ""
-    CONFIGURE_COMMAND
-    ""
     BUILD_COMMAND
-    ""
+    cmake --build . --target uav_am
+    BUILD_ALWAYS
+    ON 
+    CMAKE_ARGS 
+        -DCMAKE_C_COMPILER=${armhf-gcc}
+        -DCMAKE_C_FLAGS=${BASE_C_FLAGS}
+        -DCAKE=${CAKE}
+        -DSTATIC_LINKING=ON
+        -Dam_queue=${CMAKE_CURRENT_SOURCE_DIR}/../am_queue/
 )
+ExternalProject_Get_property(useram DOWNLOAD_DIR)
 MyAddExternalProjFilesToOverlay(
     useram
-    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    ${DOWNLOAD_DIR}/useram-build
     overlay_radio
     "usr/bin"
     FILES
-    uav
+    uav_am
 )
 
 ExternalProject_Add(

--- a/apps/case-uav-step5/vmRadio/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-uav-step5/vmRadio/overlay_files/init_scripts/inittab_hvc0
@@ -55,7 +55,7 @@ hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 ::wait:chmod g+rw /dev/uio4
 
 # Run AM
-::respawn:uav
+::respawn:uav_am /dev/uio4
 
 # Run UxAS
 # ::respawn:su uxas -c "/usr/bin/camkes_log_relay /dev/uio3 192.168.2.2:5578"

--- a/apps/case-uav-step6/vmRadio/CMakeLists.txt
+++ b/apps/case-uav-step6/vmRadio/CMakeLists.txt
@@ -159,28 +159,41 @@ function(MyAddExternalProjFilesToOverlay external_target external_install_dir ov
     endforeach()
 endfunction(MyAddExternalProjFilesToOverlay)
 
+find_program(CAKE NAMES cake32 cake PATHS "~/cake-x64-x32/" "/cake-x64-x32/" DOC "32-bit targeting CakeML compiler")
+if("${CAKE}" STREQUAL "CAKE-NOTFOUND")
+    message(FATAL_ERROR "Could not find a 32-bit targeting CakeML compiler. Please ensure cake32 is on the system path.")
+endif()
+find_program(armhf-gcc NAMES arm-linux-gnueabihf-gcc)
+if("${armhf-gcc}" STREQUAL "armhf-gcc-NOTFOUND")
+    message(FATAL_ERROR "Could not find arm-linux-gnueabihf-gcc, please install and place on the system path.")
+endif()
 ExternalProject_Add(
     useram
     GIT_REPOSITORY
-    https://github.com/gaj7/am-bin-uav.git
+    https://github.com/ku-sldg/am-cakeml.git
     GIT_TAG
-    meas
+    dev-case-exp
     INSTALL_COMMAND
     ""
-    UPDATE_COMMAND
-    ""
-    CONFIGURE_COMMAND
-    ""
     BUILD_COMMAND
-    ""
+    cmake --build . --target uav_am
+    BUILD_ALWAYS
+    ON 
+    CMAKE_ARGS 
+        -DCMAKE_C_COMPILER=${armhf-gcc}
+        -DCMAKE_C_FLAGS=${BASE_C_FLAGS}
+        -DCAKE=${CAKE}
+        -DSTATIC_LINKING=ON
+        -Dam_queue=${CMAKE_CURRENT_SOURCE_DIR}/../am_queue/
 )
+ExternalProject_Get_property(useram DOWNLOAD_DIR)
 MyAddExternalProjFilesToOverlay(
     useram
-    ${CMAKE_CURRENT_BINARY_DIR}/useram-prefix/src/useram
+    ${DOWNLOAD_DIR}/useram-build
     overlay_radio
     "usr/bin"
     FILES
-    uav
+    uav_am
 )
 
 ExternalProject_Add(

--- a/apps/case-uav-step6/vmRadio/overlay_files/init_scripts/inittab_hvc0
+++ b/apps/case-uav-step6/vmRadio/overlay_files/init_scripts/inittab_hvc0
@@ -55,7 +55,7 @@ hvc0:2345:respawn:/sbin/getty -L 9600 hvc0
 ::wait:chmod g+rw /dev/uio4
 
 # Run AM
-::respawn:uav
+::respawn:uav_am /dev/uio4
 
 # Run UxAS
 # ::respawn:su uxas -c "/usr/bin/camkes_log_relay /dev/uio3 192.168.2.2:5578"


### PR DESCRIPTION
Hello again,

I've made a number of changes to the attestation managers that I'd like to incorporate to this repo. The AM is now public, so the build process can download the source rather than the binaries. In addition, the measurements have changed greatly. We now measure the UxAS process's executable memory as it runs, along with the configuration files. The desired hash values will therefore depend on the build environment, since different compiler versions and other such factors could produce slightly different binaries. Since we are building from the docker container, this should not be a problem as long as everyone keeps the environment up to date.

The AM components also print some logging information to stdout. You can redirect their output to /dev/null or some log file if you'd prefer.

Finally, I've incorporated these changes to case-gs-step2, case-gs-threat-3A1, case-gs-threat-3A2, and case-uav-step5. Let me know if I need to incorporate it into any other apps.

Thanks,
Grant.